### PR TITLE
test(General): test out prevention of screen from scrolling up by add…

### DIFF
--- a/index.css
+++ b/index.css
@@ -172,6 +172,7 @@ object {
     top: 0;
     left: 0;
     cursor: ew-resize;
+    overflow: hidden;
 }
 
 #main--content--inner--container {
@@ -195,6 +196,10 @@ object {
 }
 
 #main--content--inner--container.vertical--scroll--allowed {
+    overflow-y: auto;
+}
+
+#main--content--general--paragraph.vertical--scroll--allowed {
     overflow-y: auto;
 }
 

--- a/index.js
+++ b/index.js
@@ -1332,7 +1332,7 @@ function allowScrollBehaviorOnMainContent () {
 }
 
 function disallowScrollBehaviorOnMainContent () {
-    let mainContentContainer = document.getElementById("main--content--inner--container");
+    let mainContentContainer = document.getElementById("main--content--inner--container");  
     mainContentContainer.classList.remove("vertical--scroll--allowed");
 }
 


### PR DESCRIPTION
…ing overflow hidden to outer container

## Description

All pages except home page have been showing strange scrolling behavior on mobile devices. As user scrolls up, the page itself scrolls up instead of just the content, which leads to undesirable visual results. Testing out change to the CSS on mobile to see whether this would fix it.

