### PR TITLE
Executive Board > Foundation Council 

### DIFF
--- a/src/app/ef/page.tsx
+++ b/src/app/ef/page.tsx
@@ -44,7 +44,7 @@ const EthereumFoundation = (props: any) => {
         </p>
 
         <div id="executive-board">
-          <h3>Meet our Executive Board</h3>
+          <h3>Meet our Foundation Council</h3>
 
           <div className="member">
             <img


### PR DESCRIPTION
Per request:

> noticed that we say “Executive Board”, It would be more accurate to say “Foundation Council”.