### PR TITLE
Add /mandate redirect to EF mandate PDF

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async redirects() {
+    return [
+      {
+        source: '/mandate',
+        destination: '/ef-mandate.pdf',
+        permanent: false,
+      },
+    ]
+  },
   webpack: (config, { webpack }) => {
     return {
       ...config,


### PR DESCRIPTION
## Summary
- Adds a redirect from `/mandate` to `/ef-mandate.pdf` so `ethereum.foundation/mandate` works as a clean URL
- Uses a temporary (302) redirect in case the destination changes later

## Test plan
- [ ] Visit `ethereum.foundation/mandate` and verify it redirects to the PDF